### PR TITLE
Convert Readme to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,13 @@
-/*
- * Readme.txt
- *
- * Copyright 2019 HIMSA II K/S - www.himsa.com. Represented by EHIMA - www.ehima.com
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+# Contents
+1.  [Introduction](#Introduction)
+2.  [Directory Structure](#Directory-Structure)
+3.  [Naming Conventions](#Naming-Conventions)
+4.  [General Code Structure](#General-Code-Structure)
+5.  [Test and Debug Support](#Test-and-Debug-Support)
 
-Contents
-========
- (1) Introduction
- (2) Directory Structure
- (3) Naming Conventions
- (4) General Code Structure
- (5) Test and Debug Support
+# 1. Introduction
+*(derived from Bluetooth SIG LC3 specification dr09r06)*
 
-(1) Introduction
-================
-(derived from Bluetooth SIG LC3 specification dr09r06)
 The Low Complexity Communication Codec (LC3) is an efficient Bluetooth Audio Codec for use in
 audio profiles. This codec can encode speech and music at a variety of bitrates. The LC3 can
 be incorporated in any Bluetooth audio profile.
@@ -48,8 +29,8 @@ to the specification, however, references in the code to the specification are n
 the latest formal changes in the specification. Thus, the revision of the specification referenced
 is given with each reference, so that it should be possible to track the links to the specification.
 
-(2) Directory Structure
-=======================
+# 2. Directory Structure
+```
   |- Api  -> include files needed by calling application code
   |- Common | -> implementation needed by LC3 encoder and decoder
   |         |-- KissFft -> source code of kissfft library used for fast transforms
@@ -58,23 +39,25 @@ is given with each reference, so that it should be possible to track the links t
   |- Encoder -> implementation of LC3 encoder (*.hpp and *.cpp)
   |- TestSupport -> interface and dummy/demo implementation of "datapoint" access
                     for test and debug support
+```
 
-(3) Naming Conventions and Coding Style
-=======================================
- Names of variables/objects have been chosen to be as close as possible
+# 3. Naming Conventions and Coding Style
+Names of variables/objects have been chosen to be as close as possible
 to the naming within the LC3 specification. This applies not only to the
 selected wording, but also to the chosen case and concatenation of words.
- Thus, variable naming may appear somewhat unorthodox to a standard C/C++ developer
+
+Thus, variable naming may appear somewhat unorthodox to a standard C/C++ developer
 and is not always consistent in style. Nevertheless, the close link to the specification
 document is considered most valuable so that this approach has been followed.
- The LC3 specification contains textual descriptions, equations, pseudo-code, tables
+
+The LC3 specification contains textual descriptions, equations, pseudo-code, tables
 and reference intermediate outputs. The naming of variables is not perfectly consistent,
 particularly in the case of names for intermediate outputs in relation to the
 specification text. Thus, there are situations where we had to select one name out of
 different options or had to choose different names for internal variables and
 "datapoints" provided for test and debug support.
 
- Some parts of the code are directly converted from pseudo-code given in
+Some parts of the code are directly converted from pseudo-code given in
 the specification document. Changes compared to the specification are made only
 when supported by technical arguments. Again, the close link to the specification
 is considered most valuable. Note that this implies in some situations that code
@@ -82,11 +65,10 @@ is not optimized in terms of computation effort, memory usage and/or clarity of 
 
 Further Conventions:
  - indentation using 4 spaces; no TABS at all
- - directory, file and class names are camel-case starting with a capital letter
+ - directory, file and class names are CamelCase starting with a capital letter
 
 
-(4) General Code Structure
-==========================
+# 4. General Code Structure
  The implementation is in C++ where object oriented programming is mainly used to
  formulate the relations of higher level modules/classes. The code of the lower level
  modules is syntactically C++, but the style is more like plain old procedural
@@ -98,8 +80,8 @@ Further Conventions:
  A brief overview on the main class relationships is summarized in the following
  basic diagrams.
 
- Encoder:
- --------
+## Encoder:
+```
  Lc3Encoder : main API and handling of multi-channel sessions
    |    |(1)------(1) Lc3Config : configuration instance
    |
@@ -113,9 +95,9 @@ Further Conventions:
                                 |(1)-----(1) EncoderFrame : toplevel processing per frame and
                                                             reallocation of sub-modules in case
                                                             of bitrate changes
-
- Decoder:
- --------
+```
+## Decoder:
+```
  Lc3Decoder : main API and handling of multi-channel sessions
    |    |(1)------(1) Lc3Config : configuration instance
    |
@@ -129,17 +111,20 @@ Further Conventions:
                                 |(1)-----(1) DecoderFrame : toplevel processing per frame and
                                                             reallocation of sub-modules in case
                                                             of bitrate changes
+```
 
+# 5. Test and Debug Support
 
-(5) Test and Debug Support
-==========================
 The development of the codec implementation has been strongly based on close match of
 intermediate values with specified reference values. To be able to access the proper
 values in a standardized manner a simple "datapoint" API has been created.
- Note: this API is not fully optimized for usage within in android but may be extended
+
+Note: this API is not fully optimized for usage within in android but may be extended
 for this purpose in future.
- The given API can be found in "TestSupport/Datapoints.hpp" with a basic (mainly dummy) implementation
-given in "TestSupport/DatapointsAndroid.cpp".
- To use this API an instance of "DatapointContainer" has to be created and provided to the
+
+The given API can be found in `TestSupport/Datapoints.hpp` with a basic (mainly dummy) implementation
+given in `TestSupport/DatapointsAndroid.cpp`.
+
+To use this API an instance of `DatapointContainer` has to be created and provided to the
 Lc3Encoder and Lc3Decoder constructors when needed. Note: that this is not intended for final releases
 due to the additional resources needed.


### PR DESCRIPTION
Converts the Readme to markdown syntax, which allows more styling, hyperlinking and better default rendering by GitHub.