### PR TITLE
Fix Encoder Crash for 8_1 (8kHz, 7.5ms, 26 octets)

### DIFF
--- a/Encoder/SpectralNoiseShaping.cpp
+++ b/Encoder/SpectralNoiseShaping.cpp
@@ -109,7 +109,7 @@ void SpectralNoiseShaping::run(const double* const X, const double* E_B, bool F_
         E_B_patched[i*2+0] = E_B[i];
         E_B_patched[i*2+1] = E_B[i];
     }
-    for (uint8_t i=0; i < lc3Config.N_b; i++)
+    for (uint8_t i=0; i < lc3Config.N_b - n2; i++)
     {
         E_B_patched[2*n2+i] = E_B[n2+i];
     }


### PR DESCRIPTION
Trying to encode with 8_1 I got a memory exception. When comparing the code to the LC3 Specification 1.0, it looks like the missing term caused the crash. After matching the code to the spec, the encoder does not crash anymore.
